### PR TITLE
Adjust: board tasks api separation

### DIFF
--- a/app/controllers/api/v1/boards_controller.rb
+++ b/app/controllers/api/v1/boards_controller.rb
@@ -2,22 +2,11 @@ class Api::V1::BoardsController < Api::ApiController
   before_action :authenticate_user, only: %i[create update show]
 
   def index
-    boards = Board.where(project_id: params[:project_id])
-                  .order(position: :asc)
+    boards = project.boards
+                    .select(:id, :title, :project_id, :position)
+                    .order(position: :asc)
 
-    tasks = Task.where(board_id: boards.ids, project_id: params[:project_id])
-                .select(:id, :title, :board_id, :project_id, :tag)
-                .with_task_title(params[:task_title])
-                .with_user_id(params[:assignee_id])
-                .with_tag(params[:tag])
-                .order(position: :asc)
-                .group_by(&:board_id)
-
-    json_boards = boards.as_json.each do |board|
-      board['tasks'] = tasks[board['id']] || []
-    end
-
-    render json: json_boards, status: :ok
+    render json: { boards: boards }, status: :ok
   end
 
   def show

--- a/app/javascript/src/api/index.js
+++ b/app/javascript/src/api/index.js
@@ -153,6 +153,17 @@ export const attachTaskImages = async ({data, token, task_id}) => {
   return response.data
 }
 
+export const getTaskSummary = async ({params, token}) => {
+  const response = await axios({
+    method: 'get',
+    url: '/api/v1/tasks/summary',
+    headers: { Authorization: token },
+    params: params
+  })
+
+  return response.data
+}
+
 // Projects
 
 export const getProjects = async ({params, token}) => {

--- a/app/javascript/src/components/Boards/Boards.jsx
+++ b/app/javascript/src/components/Boards/Boards.jsx
@@ -34,12 +34,13 @@ function Boards() {
     boards.length > BOARDS_LENGTH ? setContent('start') : setContent('center')
 
     const boardMap = boards.map(board => {
-      board.tasks = tasks[board.id]
+      board.tasks = tasks[board.id] || []
       return board
     })
 
     boardCtx.setBoards(boardMap)
   }
+
   useEffect(() => {
     combineData()
   }, [boardCtx.project_id])

--- a/app/javascript/src/components/Boards/BoardsHeader.jsx
+++ b/app/javascript/src/components/Boards/BoardsHeader.jsx
@@ -8,6 +8,7 @@ import Avatar from '@mui/material/Avatar';
 import AvatarGroup from '@mui/material/AvatarGroup';
 import BoardContext from '../../store/BoardContext';
 import UserContext from '../../store/UserContext';
+import { getIndexTasks } from '../../api'
 
 function BoardsHeader () {
   const params = useParams();
@@ -17,7 +18,8 @@ function BoardsHeader () {
   const [filter, setFilter] = useState({
     task_title: '',
     user_id: '',
-    tag: ''
+    tag: '',
+    project_id: params.project_id
   });
   const [anchorEl, setAnchorEl] = useState(null)
   const [selectedNames, setSelectedNames] = useState([])
@@ -29,10 +31,25 @@ function BoardsHeader () {
     })
   }, [])
 
+  const filterTasks = async (filter) => {
+    const tasksData = await getIndexTasks(filter)
+    const tasks = tasksData.tasks
+
+    console.log(tasks)
+    boardCtx.setBoards(prev => {
+      const boards = prev.map(board => {
+       board.tasks = tasks[board.id]
+       return board
+      })
+
+      return boards
+    })
+  }
+
   const handleSearch = (e) => {
     e.preventDefault()
 
-    boardCtx.fetchBoards(filter).then(res => boardCtx.setBoards(res))
+    filterTasks({params: filter, token: authCtx.token})
   }
 
   const handleAvatar = (e) => setAnchorEl(e.currentTarget)

--- a/app/javascript/src/components/Boards/BoardsHeader.jsx
+++ b/app/javascript/src/components/Boards/BoardsHeader.jsx
@@ -35,7 +35,6 @@ function BoardsHeader () {
     const tasksData = await getIndexTasks(filter)
     const tasks = tasksData.tasks
 
-    console.log(tasks)
     boardCtx.setBoards(prev => {
       const boards = prev.map(board => {
        board.tasks = tasks[board.id]
@@ -67,15 +66,15 @@ function BoardsHeader () {
     })
 
     if(e.currentTarget.checked) {
-      boardCtx.fetchBoards({assignee_id: [...selectedNames, member.id]})
-      .then(res => boardCtx.setBoards(res))
+      const params = {...filter, assignee_id: [...selectedNames, member.id]}
+      filterTasks({params: params, token: authCtx.token})
     } else {
-      const newArr = Array.from(selectedNames)
-      const index = newArr.indexOf(member.id)
-      newArr.splice(index, 1)
+      const nameMap = Array.from(selectedNames)
+      const index = nameMap.indexOf(member.id)
+      const params = {...filter, assignee_id: nameMap}
 
-      boardCtx.fetchBoards({assignee_id: newArr})
-      .then(res => boardCtx.setBoards(res))
+      nameMap.splice(index, 1)
+      filterTasks({params: params, token: authCtx.token})
     }
   }
 

--- a/app/javascript/src/components/Tasks/UpdateTaskForm.jsx
+++ b/app/javascript/src/components/Tasks/UpdateTaskForm.jsx
@@ -14,7 +14,7 @@ import {
 import { EditableContent, EditableContentV2, NewComment, Comments } from '../index';
 import AuthContext from "../../store/AuthContext";
 import UserContext from "../../store/UserContext";
-import { UpdateTask, attachTaskImages } from '../../api'
+import { UpdateTask, attachTaskImages, getIndexTasks } from '../../api'
 import BoardContext from "../../store/BoardContext";
 
 function UpdateTaskForm ({ task, modalOpen, setModalOpen, setTask }){
@@ -34,15 +34,25 @@ function UpdateTaskForm ({ task, modalOpen, setModalOpen, setTask }){
 
   const handleClose = () => {
     if(refetchOnClose) {
-      boardCtx.fetchBoards()
-      .then(res => boardCtx.setBoards(res))
+      const params = { project_id: boardCtx.project_id }
+      getIndexTasks({params: params, token: authCtx.token})
+      .then(res => {
+        boardCtx.setBoards(prev => {
+          const boards = prev.map(board => {
+            board.tasks = res.tasks[board.id] || []
+            return board
+          })
+
+          return boards
+        })
+      })
     }
+
     setModalOpen(false)
   }
 
   const handleChange = async ({value, attribute}) => {
     let params = {task: { [attribute]: String(value)},  task_id: task.id }
-    console.log(params)
     const updateResponse = await UpdateTask({
       params: params,
       token: authCtx.token,

--- a/app/javascript/src/pages/Home.jsx
+++ b/app/javascript/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { TasksTable } from '../components/index'
-import { getIndexTasks, getAssignedProjects } from '../api/index'
+import { getTaskSummary, getAssignedProjects } from '../api/index'
 import AuthContext from "../store/AuthContext";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from "chart.js";
 import { Doughnut } from "react-chartjs-2";
@@ -15,7 +15,7 @@ function Home(){
   const authCtx = useContext(AuthContext)
 
   useEffect(() => {
-    getIndexTasks({token: authCtx.token})
+    getTaskSummary({token: authCtx.token})
     .then(res => {
       setTasks(res.tasks)
       setSummary(res.task_summary)
@@ -41,7 +41,7 @@ function Data({ tasks, setTasks, summary, setSummary }) {
     if(!val) return
 
     setProjectInput(val)
-    getIndexTasks({params: {project_id: val.id},token: authCtx.token})
+    getTaskSummary({params: {project_id: val.id}, token: authCtx.token})
     .then(res => {
       setTasks(res.tasks)
       setSummary(res.task_summary)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       resources :tasks, only: %i[index show create update], param: :task_id do
         collection do
           post :import_tasks
+          get :summary
         end
         member do
           patch :upload_files

--- a/spec/factories/boards.rb
+++ b/spec/factories/boards.rb
@@ -12,8 +12,14 @@ FactoryBot.define do
       title { 'Stage Testing' }
     end
 
+    trait :multiple do
+      sequence(:title) { |title| "Board #{title}" }
+    end
+
     sequence(:position)
 
     association :project
+
+    factory :multiple_boards, traits: %i[multiple]
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     sequence(:position)
 
     trait :multiple_tasks do
-      sequence(:title) { |title_num| "Task Number #{title_num}" }
+      sequence(:title) { |num| "Task Number #{num}" }
     end
 
     trait :random_title do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     trait :random_credentials do
       first_name { Faker::Name.unique.first_name }
       last_name { Faker::Name.last_name   }
-      account { first_name }
+      account { first_name.downcase + SecureRandom.alphanumeric(2) }
       email { "#{account}@email.com" }
     end
 

--- a/spec/requests/boards_spec.rb
+++ b/spec/requests/boards_spec.rb
@@ -3,16 +3,23 @@ require 'rails_helper'
 RSpec.describe "Boards", type: :request do
   let(:user) { create(:user) }
   let(:project) { create(:project, owner: user) }
+  let(:boards) { create_list(:multiple_boards, 4, project: project) }
+
   describe "GET /index" do
     before do
       sign_in(user)
+      boards
       @token = response_body[:token]
     end
 
     it 'returns SUCCESS response' do
-      get(api_v1_boards_path, headers: { Authorization: @token })
+      get(api_v1_boards_path, {
+        headers: { Authorization: @token },
+        params: { project_id: project.id }
+      })
 
       expect(response).to have_http_status(200)
+      expect(response_body[:boards]).to be_present
     end
   end
 


### PR DESCRIPTION
Separates the Task query from the boards index API for a more optimize API usage, more code readability and easier testing.